### PR TITLE
pipup (3)

### DIFF
--- a/{{cookiecutter.project_name}}/requirements-dev.txt
+++ b/{{cookiecutter.project_name}}/requirements-dev.txt
@@ -1,10 +1,10 @@
 fabric2==2.7.0
 patchwork==1.0.1
 django-debug-toolbar==3.5.0
-tox==3.25.0
+tox==3.25.1
 pytest==7.1.2
 pylama==8.3.8
-requests==2.28.0
+requests==2.28.1
 mypy==0.961
 django-stubs==1.12.0
 types-PyYAML==6.0.9

--- a/{{cookiecutter.project_name}}/requirements.txt
+++ b/{{cookiecutter.project_name}}/requirements.txt
@@ -7,5 +7,5 @@ pyyaml==6.0
 django-sendgrid-v5==1.2.0
 whitenoise==6.2.0
 celery==5.2.7
-django-celery-results==2.3.1
+django-celery-results==2.4.0
 git+https://github.com/celery/django-celery-beat.git@v2.3.0#egg=django-celery-beat # pending new release: https://github.com/celery/django-celery-beat/issues/465


### PR DESCRIPTION
{{cookiecutter.project_name}}/requirements.txt:
* django-celery-results: 2.3.1 -> 2.4.0

{{cookiecutter.project_name}}/requirements-dev.txt:
* requests: 2.28.0 -> 2.28.1
* tox: 3.25.0 -> 3.25.1